### PR TITLE
Update ReactDOM.render to ReactDOM.hydrate

### DIFF
--- a/src/entryPoint.js
+++ b/src/entryPoint.js
@@ -18,7 +18,7 @@ export function entryPoint({
   const store = createStore({ reducers, initialState, apiMiddleware });
 
   const render = (Component) => {
-    ReactDOM.render((
+    ReactDOM.hydrate((
       <AppContainer>
         <BrowserRouter forceRefresh={!supportsHistory}>
           <Provider store={store}>


### PR DESCRIPTION
```Warning: render(): Calling ReactDOM.render() to hydrate server-rendered markup will stop working in React v17. Replace the ReactDOM.render() call with ReactDOM.hydrate() if you want React to attach to the server HTML.```