### PR TITLE
Raw content if content-type is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gasbuddy/react",
-  "version": "8.1.3",
+  "version": "8.2.0",
   "description": "GasBuddy Platform for Web Projects",
   "main": "build/index.js",
   "module": "build-webpack/index.js",

--- a/src/fetchApi.js
+++ b/src/fetchApi.js
@@ -20,8 +20,10 @@ export async function fetchApi(request) {
     .then(async (response) => {
       const { headers, status } = response;
       let responseBody;
-      const contentType = response.headers.get('content-type').toLowerCase();
-      if (contentType && contentType.includes('application/json')) {
+      const contentType = response.headers.get('content-type')?.toLowerCase();
+      if (!contentType) {
+        responseBody = await response.text();
+      } else if (contentType.includes('application/json')) {
         responseBody = await response.json();
       } else {
         responseBody = await response.blob();


### PR DESCRIPTION
Return raw text if content-type is not defined.
This will fix the cases when server doesn't return any content (204 and some 404), and content-type is not required.